### PR TITLE
CEF CommandLine Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,11 @@ An array containing information about each single extension that will be added t
 		<td valign="top">Main ExtendScript file for the extension.</td>
 	</tr>
 	<tr>
+		<td valign="top"><strong>cef_params</strong></td>
+		<td valign="top">Array</td>
+		<td valign="top"> <a href="https://github.com/Adobe-CEP/CEP-Resources/wiki/CEP-6-HTML-Extension-Cookbook-for-CC-2015#command_line_parameters">Commonly used CEF command parameters</a> </td>
+	</tr>
+	<tr>
 		<td valign="top"><strong>icons</strong></td>
 		<td valign="top">Object</td>
 		<td valign="top">Extension icons, each icon should be a 23x23px PNG. Check the default values in the <code>/options/defaults.js</code> source file for a full description of the object.</td>

--- a/res/bundle/manifest.extension.xml
+++ b/res/bundle/manifest.extension.xml
@@ -2,9 +2,10 @@
 	<DispatchInfo>
 		<Resources>
 			<MainPath>./<%= extension.main_path %></MainPath>
-			    <CEFCommandLine>
-                <%= cef_params %>
-                </CEFCommandLine>
+			<ScriptPath>./<%= extension.script_path %></ScriptPath>
+		    <CEFCommandLine>
+            	<%= cef_params %>
+            </CEFCommandLine>
 		</Resources>
 		<Lifecycle>
 			<AutoVisible>true</AutoVisible>

--- a/res/bundle/manifest.extension.xml
+++ b/res/bundle/manifest.extension.xml
@@ -2,7 +2,9 @@
 	<DispatchInfo>
 		<Resources>
 			<MainPath>./<%= extension.main_path %></MainPath>
-			<ScriptPath>./<%= extension.script_path %></ScriptPath>
+			    <CEFCommandLine>
+                <%= cef_params %>
+                </CEFCommandLine>
 		</Resources>
 		<Lifecycle>
 			<AutoVisible>true</AutoVisible>
@@ -25,13 +27,14 @@
 				</MinSize>
 			</Geometry>
       <Icons>
-        <Icon Type="Normal">./<%= extension.icons.light.normal %></Icon>
-        <Icon Type="RollOver">./<%= extension.icons.light.hover %></Icon>
-        <Icon Type="Disabled">./<%= extension.icons.light.disabled %></Icon>
-        <Icon Type="DarkNormal">./<%= extension.icons.dark.normal %></Icon>
-        <Icon Type="DarkRollOver">./<%= extension.icons.dark.hover %></Icon>
-        <Icon Type="DarkDisabled">./<%= extension.icons.dark.disabled %></Icon>
+        <Icon Type="Normal">./<%= extension.icons.panel.light.normal %></Icon>
+        <Icon Type="RollOver">./<%= extension.icons.panel.light.hover %></Icon>
+        <Icon Type="Disabled">./<%= extension.icons.panel.light.disabled %></Icon>
+        <Icon Type="DarkNormal">./<%= extension.icons.panel.dark.normal %></Icon>
+        <Icon Type="DarkRollOver">./<%= extension.icons.panel.dark.hover %></Icon>
+        <Icon Type="DarkDisabled">./<%= extension.icons.panel.dark.disabled %></Icon>
       </Icons>
 		</UI>
 	</DispatchInfo>
 </Extension>
+

--- a/res/bundle/manifest.extension.xml
+++ b/res/bundle/manifest.extension.xml
@@ -27,12 +27,12 @@
 				</MinSize>
 			</Geometry>
       <Icons>
-        <Icon Type="Normal">./<%= extension.icons.panel.light.normal %></Icon>
-        <Icon Type="RollOver">./<%= extension.icons.panel.light.hover %></Icon>
-        <Icon Type="Disabled">./<%= extension.icons.panel.light.disabled %></Icon>
-        <Icon Type="DarkNormal">./<%= extension.icons.panel.dark.normal %></Icon>
-        <Icon Type="DarkRollOver">./<%= extension.icons.panel.dark.hover %></Icon>
-        <Icon Type="DarkDisabled">./<%= extension.icons.panel.dark.disabled %></Icon>
+        <Icon Type="Normal">./<%= extension.icons.light.normal %></Icon>
+        <Icon Type="RollOver">./<%= extension.icons.light.hover %></Icon>
+        <Icon Type="Disabled">./<%= extension.icons.light.disabled %></Icon>
+        <Icon Type="DarkNormal">./<%= extension.icons.dark.normal %></Icon>
+        <Icon Type="DarkRollOver">./<%= extension.icons.dark.hover %></Icon>
+        <Icon Type="DarkDisabled">./<%= extension.icons.dark.disabled %></Icon>
       </Icons>
 		</UI>
 	</DispatchInfo>

--- a/res/bundle/manifest.extension.xml
+++ b/res/bundle/manifest.extension.xml
@@ -10,7 +10,7 @@
 			<AutoVisible>true</AutoVisible>
 		</Lifecycle>
 		<UI>
-			<Type>Panel</Type>
+			<Type><%= extension.type %></Type>
 			<Menu><%= extension.name %></Menu>
 			<Geometry>
 				<Size>

--- a/tasks/lib/xml.js
+++ b/tasks/lib/xml.js
@@ -48,6 +48,14 @@ module.exports = function (grunt)
 
         build.extensions.forEach(function (extension)
         {
+            //<CEFCommandLine>
+            var cef_params = [];
+            extension.cef_params.forEach(function(cef_param)
+            {
+                cef_params.push('<Parameter>'+ cef_param +'</Parameter>')
+            });
+            extension.cef_params = cef_params.join('\n\t\t\t\t\t');
+
             var data = _.extend({}, { 'extension': extension, 'build': build, });
 
             // <ExtensionList>


### PR DESCRIPTION
I'm running through the [CEP Samples](https://github.com/Adobe-CEP/Samples/tree/master/CEP_HTML_Test_Extension) and have added in `cef_params` option. 
Also added a `type` option for  support for __modalDialog__ and __Modeless__, and removed the `panel` node in the config as a result.
Have a look at [this gist](https://gist.github.com/jDmacD/cdfda1ab361508f84787), it's basically a port of a CEP Sample to grunt-cep.