### PR TITLE
Updated Mac folder names

### DIFF
--- a/tasks/lib/hosts.json
+++ b/tasks/lib/hosts.json
@@ -5,7 +5,7 @@
             "name": "Photoshop",
             "ids": [ "PHXS", "PHSP" ],
             "version": { "min": "16.0", "max": "16.9" },
-            "bin": { "win": "Photoshop.exe", "mac": "Adobe Photoshop CC 2015/Adobe Photoshop CC 2015.app" },
+            "bin": { "win": "Photoshop.exe", "mac": "Adobe Photoshop CC 2015.app" },
             "x64": true
         },
         "illustrator": {
@@ -13,7 +13,7 @@
             "name": "Illustrator",
             "ids": [ "ILST" ],
             "version": { "min": "19.0", "max": "19.9" },
-            "bin": { "win": "Support Files/Contents/Windows/Illustrator.exe", "mac": "Adobe Illustrator CC 2015/Adobe Illustrator CC 2015.app" },
+            "bin": { "win": "Support Files/Contents/Windows/Illustrator.exe", "mac": "Adobe Illustrator CC 2015.app" },
             "x64": true
         },
         "indesign": {
@@ -21,7 +21,7 @@
             "name": "InDesign",
             "ids": [ "IDSN" ],
             "version": { "min": "11.0", "max": "11.9" },
-            "bin": { "win": "InDesign.exe", "mac": "Adobe InDesign CC 2015/Adobe InDesign CC 2015.app" },
+            "bin": { "win": "InDesign.exe", "mac": "Adobe InDesign CC 2015.app" },
             "x64": true
         },
         "flash": {
@@ -29,7 +29,7 @@
             "name": "Flash",
             "ids": [ "FLPR" ],
             "version": { "min": "15.0", "max": "15.9" },
-            "bin": { "win": "Flash.exe", "mac": "Adobe Flash CC 2015/Adobe Flash CC 2015.app" },
+            "bin": { "win": "Flash.exe", "mac": "Adobe Flash CC 2015.app" },
             "x64": true
         },
         "aftereffects": {
@@ -37,7 +37,7 @@
             "name": "After Effects",
             "ids": [ "AEFT" ],
             "version": { "min": "14.0", "max": "14.9" },
-            "bin": { "win": "Support Files/AfterFX.exe", "mac": "Adobe After Effects CC 2015/Adobe After Effects CC 2015.app" },
+            "bin": { "win": "Support Files/AfterFX.exe", "mac": "Adobe After Effects CC 2015.app" },
             "x64": true
         },
         "premiere": {
@@ -45,7 +45,7 @@
             "name": "Premiere",
             "ids": [ "PPRO" ],
             "version": { "min": "9.0", "max": "9.9" },
-            "bin": { "win": "Adobe Premiere Pro.exe", "mac": "Adobe Premiere Pro CC 2015/Adobe Premiere Pro CC 2015.app" },
+            "bin": { "win": "Adobe Premiere Pro.exe", "mac": "Adobe Premiere Pro CC 2015.app" },
             "x64": true
         },
         "prelude": {
@@ -53,7 +53,7 @@
             "name": "Prelude",
             "ids": [ "PRLD" ],
             "version": { "min": "4.0", "max": "4.9" },
-            "bin": { "win": "Prelude.exe", "mac": "Adobe Prelude CC 2015/Adobe Prelude CC 2015.app" },
+            "bin": { "win": "Prelude.exe", "mac": "Adobe Prelude CC 2015.app" },
             "x64": false
         },
         "dreamweaver": {
@@ -61,7 +61,7 @@
             "name": "Dreamweaver",
             "ids": [ "DRWV" ],
             "version": { "min": "15.0", "max": "15.9" },
-            "bin": { "win": "Dreamweaver.exe", "mac": "Adobe Dreamweaver CC 2015/Adobe Dreamweaver CC 2015.app" },
+            "bin": { "win": "Dreamweaver.exe", "mac": "Adobe Dreamweaver CC 2015.app" },
             "x64": false
         },
         "incopy": {
@@ -69,7 +69,7 @@
             "name": "InCopy",
             "ids": [ "AICY" ],
             "version": { "min": "11.0", "max": "11.9" },
-            "bin": { "win": "InCopy.exe", "mac": "Adobe InCopy CC 2015/Adobe InCopy CC 2015.app" },
+            "bin": { "win": "InCopy.exe", "mac": "Adobe InCopy CC 2015.app" },
             "x64": true
         }
     },
@@ -79,7 +79,7 @@
             "name": "Photoshop",
             "ids": [ "PHXS", "PHSP" ],
             "version": { "min": "15.0", "max": "15.9" },
-            "bin": { "win": "Photoshop.exe", "mac": "Adobe Photoshop CC 2014/Adobe Photoshop CC 2014.app" },
+            "bin": { "win": "Photoshop.exe", "mac": "Adobe Photoshop CC 2014.app" },
             "x64": true
         },
         "illustrator": {
@@ -87,7 +87,7 @@
             "name": "Illustrator",
             "ids": [ "ILST" ],
             "version": { "min": "18.0", "max": "18.9" },
-            "bin": { "win": "Support Files/Contents/Windows/Illustrator.exe", "mac": "Adobe Illustrator CC 2014/Adobe Illustrator CC 2014.app" },
+            "bin": { "win": "Support Files/Contents/Windows/Illustrator.exe", "mac": "Adobe Illustrator CC 2014.app" },
             "x64": true
         },
         "indesign": {
@@ -95,7 +95,7 @@
             "name": "InDesign",
             "ids": [ "IDSN" ],
             "version": { "min": "10.0", "max": "10.9" },
-            "bin": { "win": "InDesign.exe", "mac": "Adobe InDesign CC 2014/Adobe InDesign CC 2014.app" },
+            "bin": { "win": "InDesign.exe", "mac": "Adobe InDesign CC 2014.app" },
             "x64": true
         },
         "flash": {
@@ -103,7 +103,7 @@
             "name": "Flash",
             "ids": [ "FLPR" ],
             "version": { "min": "14.0", "max": "14.9" },
-            "bin": { "win": "Flash.exe", "mac": "Adobe Flash CC 2014/Adobe Flash CC 2014.app" },
+            "bin": { "win": "Flash.exe", "mac": "Adobe Flash CC 2014.app" },
             "x64": true
         },
         "aftereffects": {
@@ -111,7 +111,7 @@
             "name": "After Effects",
             "ids": [ "AEFT" ],
             "version": { "min": "13.0", "max": "13.9" },
-            "bin": { "win": "Support Files/AfterFX.exe", "mac": "Adobe After Effects CC 2014/Adobe After Effects CC 2014.app" },
+            "bin": { "win": "Support Files/AfterFX.exe", "mac": "Adobe After Effects CC 2014.app" },
             "x64": true
         },
         "premiere": {
@@ -119,7 +119,7 @@
             "name": "Premiere",
             "ids": [ "PPRO" ],
             "version": { "min": "8.0", "max": "8.9" },
-            "bin": { "win": "Adobe Premiere Pro.exe", "mac": "Adobe Premiere Pro CC 2014/Adobe Premiere Pro CC 2014.app" },
+            "bin": { "win": "Adobe Premiere Pro.exe", "mac": "Adobe Premiere Pro CC 2014.app" },
             "x64": true
         },
         "prelude": {
@@ -127,7 +127,7 @@
             "name": "Prelude",
             "ids": [ "PRLD" ],
             "version": { "min": "3.0", "max": "3.9" },
-            "bin": { "win": "Prelude.exe", "mac": "Adobe Prelude CC 2014/Adobe Prelude CC 2014.app" },
+            "bin": { "win": "Prelude.exe", "mac": "Adobe Prelude CC 2014.app" },
             "x64": false
         },
         "dreamweaver": {
@@ -135,7 +135,7 @@
             "name": "Dreamweaver",
             "ids": [ "DRWV" ],
             "version": { "min": "14.0", "max": "14.9" },
-            "bin": { "win": "Dreamweaver.exe", "mac": "Adobe Dreamweaver CC 2014/Adobe Dreamweaver CC 2014.app" },
+            "bin": { "win": "Dreamweaver.exe", "mac": "Adobe Dreamweaver CC 2014.app" },
             "x64": false
         },
         "incopy": {
@@ -143,7 +143,7 @@
             "name": "InCopy",
             "ids": [ "AICY" ],
             "version": { "min": "10.0", "max": "10.9" },
-            "bin": { "win": "InCopy.exe", "mac": "Adobe InCopy CC 2014/Adobe InCopy CC 2014.app" },
+            "bin": { "win": "InCopy.exe", "mac": "Adobe InCopy CC 2014.app" },
             "x64": true
         }
     },
@@ -153,7 +153,7 @@
             "name": "Photoshop",
             "ids": [ "PHXS", "PHSP" ],
             "version": { "min": "14.0", "max": "14.9" },
-            "bin": { "win": "Photoshop.exe", "mac": "Adobe Photoshop CC/Adobe Photoshop CC.app" },
+            "bin": { "win": "Photoshop.exe", "mac": "Adobe Photoshop CC.app" },
             "x64": true
         },
         "illustrator": {
@@ -161,7 +161,7 @@
             "name": "Illustrator",
             "ids": [ "ILST" ],
             "version": { "min": "17.0", "max": "17.9" },
-            "bin": { "win": "Support Files/Contents/Windows/Illustrator.exe", "mac": "Adobe Illustrator CC/Adobe Illustrator CC.app" },
+            "bin": { "win": "Support Files/Contents/Windows/Illustrator.exe", "mac": "Adobe Illustrator CC.app" },
             "x64": true
         },
         "indesign": {
@@ -169,7 +169,7 @@
             "name": "InDesign",
             "ids": [ "IDSN" ],
             "version": { "min": "9.0", "max": "9.9" },
-            "bin": { "win": "InDesign.exe", "mac": "Adobe InDesign CC/Adobe InDesign CC.app" },
+            "bin": { "win": "InDesign.exe", "mac": "Adobe InDesign CC.app" },
             "x64": true
         },
         "flash": {
@@ -177,7 +177,7 @@
             "name": "Flash",
             "ids": [ "FLPR" ],
             "version": { "min": "13.0", "max": "13.9" },
-            "bin": { "win": "Flash.exe", "mac": "Adobe Flash CC/Adobe Flash CC.app" },
+            "bin": { "win": "Flash.exe", "mac": "Adobe Flash CC.app" },
             "x64": true
         },
         "aftereffects": {
@@ -185,7 +185,7 @@
             "name": "After Effects",
             "ids": [ "AEFT" ],
             "version": { "min": "12.0", "max": "12.9" },
-            "bin": { "win": "Support Files/AfterFX.exe", "mac": "Adobe After Effects CC/Adobe After Effects CC.app" },
+            "bin": { "win": "Support Files/AfterFX.exe", "mac": "Adobe After Effects CC.app" },
             "x64": true
         },
         "premiere": {
@@ -193,7 +193,7 @@
             "name": "Premiere",
             "ids": [ "PPRO" ],
             "version": { "min": "7.0", "max": "7.9" },
-            "bin": { "win": "Adobe Premiere Pro.exe", "mac": "Adobe Premiere Pro CC/Adobe Premiere Pro CC.app" },
+            "bin": { "win": "Adobe Premiere Pro.exe", "mac": "Adobe Premiere Pro CC.app" },
             "x64": true
         },
         "prelude": {
@@ -201,7 +201,7 @@
             "name": "Prelude",
             "ids": [ "PRLD" ],
             "version": { "min": "2.0", "max": "2.9" },
-            "bin": { "win": "Prelude.exe", "mac": "Adobe Prelude CC/Adobe Prelude CC.app" },
+            "bin": { "win": "Prelude.exe", "mac": "Adobe Prelude CC.app" },
             "x64": false
         },
         "dreamweaver": {
@@ -209,7 +209,7 @@
             "name": "Dreamweaver",
             "ids": [ "DRWV" ],
             "version": { "min": "13.0", "max": "13.9" },
-            "bin": { "win": "Dreamweaver.exe", "mac": "Adobe Dreamweaver CC/Adobe Dreamweaver CC.app" },
+            "bin": { "win": "Dreamweaver.exe", "mac": "Adobe Dreamweaver CC.app" },
             "x64": false
         },
         "incopy": {
@@ -217,7 +217,7 @@
             "name": "InCopy",
             "ids": [ "AICY" ],
             "version": { "min": "9.0", "max": "9.9" },
-            "bin": { "win": "InCopy.exe", "mac": "Adobe InCopy CC/Adobe InCopy CC.app" },
+            "bin": { "win": "InCopy.exe", "mac": "Adobe InCopy CC.app" },
             "x64": true
         }
     }


### PR DESCRIPTION
`grunt-cep` was generating folder paths like `/Applications/Adobe Prelude CC 2015/Adobe Prelude CC 2015/Adobe Prelude CC 2015.app`. This removes the folder names from `hosts.json`