### PR TITLE
Correct AEFT version nums for 2014 and 2015

### DIFF
--- a/tasks/lib/hosts.json
+++ b/tasks/lib/hosts.json
@@ -36,7 +36,7 @@
             "familyname": "AfterEffects",
             "name": "After Effects",
             "ids": [ "AEFT" ],
-            "version": { "min": "14.0", "max": "14.9" },
+            "version": { "min": "13.5", "max": "13.9" },
             "bin": { "win": "Support Files/AfterFX.exe", "mac": "Adobe After Effects CC 2015.app" },
             "x64": true
         },
@@ -110,7 +110,7 @@
             "familyname": "AfterEffects",
             "name": "After Effects",
             "ids": [ "AEFT" ],
-            "version": { "min": "13.0", "max": "13.9" },
+            "version": { "min": "13.0", "max": "13.4" },
             "bin": { "win": "Support Files/AfterFX.exe", "mac": "Adobe After Effects CC 2014.app" },
             "x64": true
         },


### PR DESCRIPTION
The 2015 release of After Effects was actually 13.5. 2014 effectively runs from 13.0 to 13.4, and 2015 starts at 13.5.