### PR TITLE
Fix early exit when package.update options are missing

### DIFF
--- a/tasks/cep.js
+++ b/tasks/cep.js
@@ -301,6 +301,8 @@ module.exports = function (grunt)
                 {
                     if (options['package'].update.enabled)
                         xml.update(callback, options);
+                    else
+                        callback();
                 },
 
                 /**


### PR DESCRIPTION
If `options['package'].update.enabled` is false, grunt would exit without building the final .ZXP, and wouldn't run any tasks after `cep:release`. This simply ensures the callback is always called.