### PR TITLE
Fix Mac process kill command

### DIFF
--- a/tasks/lib/compiler.js
+++ b/tasks/lib/compiler.js
@@ -231,8 +231,8 @@ module.exports = function (grunt)
                 }
                 else
                 {
-                    options.cmd = 'kill';
-                    options.args = ['-9', '`ps -ef | grep "' + launch_config.host.bin.mac + '" | grep -v grep | awk \'{print $2}\'`'];
+                    options.cmd = 'killall';
+                    options.args = [launch_config.host.bin.mac.slice(0, -4)];
                 }
 
                 grunt.verbose.writeln((options.cmd + ' ' + options.args.join(' ')).magenta)


### PR DESCRIPTION
The current kill command does not work on Mac systems, shown in this verbose output:
```
Launching application...
kill -9 `ps -ef | grep "Adobe Prelude CC 2015.app" | grep -v grep | awk '{print $2}'`
kill: illegal process id: `ps -ef | grep "Adobe Prelude CC 2015.app" | grep -v grep | awk '{print $2}'`
defaults write ...
```

This pull request changes the command to use a much simpler `killall`:
```
Launching application...
killall Adobe Prelude CC 2015
defaults write ...
```