### PR TITLE
Fix #21 Changed Flash family name in hosts.json for CC2018 and CC2017

### DIFF
--- a/tasks/lib/hosts.json
+++ b/tasks/lib/hosts.json
@@ -25,7 +25,7 @@
             "x64": true
         },
         "flash": {
-            "familyname": "Animate",
+            "familyname": "Flash",
             "name": "Animate",
             "ids": [ "FLPR" ],
             "version": { "min": "18.0", "max": "18.9" },
@@ -99,7 +99,7 @@
             "x64": true
         },
         "flash": {
-            "familyname": "Animate",
+            "familyname": "Flash",
             "name": "Animate",
             "ids": [ "FLPR" ],
             "version": { "min": "16.0", "max": "16.9" },


### PR DESCRIPTION
The fix changes the familyname property in the hosts.json file for flash from "Animate" back to "Flash" for the CC2018 and CC2017 versions, to resolve installation issues of the zxp bundle.