### PR TITLE
Add Premiere Rush support

### DIFF
--- a/res/.debug
+++ b/res/.debug
@@ -29,6 +29,9 @@
 
       <!-- InCopy -->
       <Host Name="AICY" Port="<%= build.launch.host_port + (i * 100) + 8 %>" />
+
+      <!-- Rush -->
+      <Host Name="RUSH" Port="<%= build.launch.host_port + (i * 100) + 9 %>" />
     </HostList>
   </Extension>
   <% } %>

--- a/tasks/lib/hosts.json
+++ b/tasks/lib/hosts.json
@@ -48,6 +48,15 @@
             "bin": { "win": "Adobe Premiere Pro.exe", "mac": "Adobe Premiere Pro CC 2019.app" },
             "x64": true
         },
+        "rush": {
+            "familyname": "Premiere",
+            "name": "Premiere Rush",
+            "ids": [ "RUSH" ],
+            "version": { "min": "1.0", "max": "1.9" },
+            "bin": { "win": "Adobe Premiere Rush.exe", "mac": "Adobe Premiere Rush CC.app" },
+            "folder": "Adobe Premiere Rush CC",
+            "x64": true
+        },
         "prelude": {
             "familyname": "Prelude",
             "name": "Prelude",


### PR DESCRIPTION
Adobe's slimmed down version of PPro, Rush, supports CEP extensions; some details here: https://github.com/Adobe-CEP/CEP-Resources/blob/5880e20b7cb2dc09e6b226f15a33165a08c0d831/CEP_9.x/Documentation/CEP%209.0%20HTML%20Extension%20Cookbook.md#applications-integrated-with-cep

PR adds a new host definition to the CC2019 family & .debug port for it.
I've reused the Premiere family name since it's in the product name, and it doesn't seem to cause any issues when building a panel which targets both Rush and Pro.
Note I have only tested the launch config on macOS, not Windows, but the paths should be correct.

If you are testing this, extensions are somewhat hidden away in this application.
1) Click the blue plus button and select Media
2) Click the back button to get out of the file browser
3) Scroll down, extensions are listed as import sources at the bottom of the list
<img width="200" alt="screenshot 2019-02-08 at 14 53 31" src="https://user-images.githubusercontent.com/1284739/52485823-9fb29f00-2bb1-11e9-8ff5-55668c45399e.png">
