### PR TITLE
Fix Mac OS CC2020 Illustrator Path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ build
 .grunt
 
 node_modules
+/.idea

--- a/tasks/lib/hosts.json
+++ b/tasks/lib/hosts.json
@@ -13,7 +13,7 @@
             "name": "Illustrator",
             "ids": [ "ILST" ],
             "version": { "min": "24.0", "max": "24.9" },
-            "bin": { "win": "Support Files/Contents/Windows/Illustrator.exe", "mac": "Adobe Illustrator 2020.app" },
+            "bin": { "win": "Support Files/Contents/Windows/Illustrator.exe", "mac": "Adobe Illustrator.app" },
             "x64": true
         },
         "indesign": {


### PR DESCRIPTION
This points to the correct name of the Illustrator executable on Mac OS 

Fixes issue #41 