### PR TITLE
Add support for CC 2026 apps

### DIFF
--- a/res/bundle/manifest.bundle.cc2026.xml
+++ b/res/bundle/manifest.bundle.cc2026.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ExtensionManifest Version="7.0" ExtensionBundleId="<%= bundle.id %>" ExtensionBundleName="<%= bundle.name %>" ExtensionBundleVersion="<%= bundle.version %>" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Author><![CDATA[<%= bundle.author_name %>]]></Author>
+	<ExtensionList>
+    <%= extension_list %>
+	</ExtensionList>
+	<ExecutionEnvironment>
+		<HostList>
+			<%= hosts %>
+		</HostList>
+		<LocaleList>
+			<Locale Code="All" />
+		</LocaleList>
+		<RequiredRuntimeList>
+			<RequiredRuntime Name="CSXS" Version="12.0" />
+		</RequiredRuntimeList>
+	</ExecutionEnvironment>
+	<DispatchInfoList>
+    <%= extensions %>
+  </DispatchInfoList>
+</ExtensionManifest>

--- a/tasks/lib/cep.js
+++ b/tasks/lib/cep.js
@@ -39,7 +39,7 @@ module.exports = function (grunt)
 
         if (!family)
         {
-            family = 'CC2025';
+            family = 'CC2026';
         }
 
         if (!HOSTS.hasOwnProperty(family))

--- a/tasks/lib/compiler.js
+++ b/tasks/lib/compiler.js
@@ -197,6 +197,7 @@ module.exports = function (grunt)
                     'CC2023': '2023',
                     'CC2024': '2024',
                     'CC2025': '2025',
+                    'CC2026': '2026',
                 };
 
                 var folder_name = launch_config.host.hasOwnProperty('folder') ? launch_config.host.folder : '/Adobe ' + launch_config.host.name + ' ' + folder_family[launch_config.family];
@@ -303,6 +304,7 @@ module.exports = function (grunt)
                             'CC2023': path.join(process.env['HOME'], '/Library/Preferences/com.adobe.CSXS.11.plist'),
                             'CC2024': path.join(process.env['HOME'], '/Library/Preferences/com.adobe.CSXS.11.plist'),
                             'CC2025': path.join(process.env['HOME'], '/Library/Preferences/com.adobe.CSXS.12.plist'),
+                            'CC2026': path.join(process.env['HOME'], '/Library/Preferences/com.adobe.CSXS.12.plist'),
                         };
 
                         if (!PLIST.hasOwnProperty(family))
@@ -332,6 +334,7 @@ module.exports = function (grunt)
                             'CC2023': 'HKEY_CURRENT_USER\\Software\\Adobe\\CSXS.11\\',
                             'CC2024': 'HKEY_CURRENT_USER\\Software\\Adobe\\CSXS.11\\',
                             'CC2025': 'HKEY_CURRENT_USER\\Software\\Adobe\\CSXS.12\\',
+                            'CC2026': 'HKEY_CURRENT_USER\\Software\\Adobe\\CSXS.12\\',
                         };
 
                         if (!PLIST.hasOwnProperty(family))

--- a/tasks/lib/hosts.json
+++ b/tasks/lib/hosts.json
@@ -1,4 +1,78 @@
 {
+    "CC2026": {
+        "photoshop": {
+            "familyname": "Photoshop",
+            "name": "Photoshop",
+            "ids": ["PHXS", "PHSP"],
+            "version": { "min": "27.0", "max": "27.9" },
+            "bin": { "win": "Photoshop.exe", "mac": "Adobe Photoshop 2026.app" },
+            "x64": true
+        },
+        "illustrator": {
+            "familyname": "Illustrator",
+            "name": "Illustrator",
+            "ids": ["ILST"],
+            "version": { "min": "30.0", "max": "30.9" },
+            "bin": { "win": "Support Files/Contents/Windows/Illustrator.exe", "mac": "Adobe Illustrator.app" },
+            "x64": true
+        },
+        "indesign": {
+            "familyname": "InDesign",
+            "name": "InDesign",
+            "ids": ["IDSN"],
+            "version": { "min": "21.0", "max": "21.9" },
+            "bin": { "win": "InDesign.exe", "mac": "Adobe InDesign 2026.app" },
+            "x64": true
+        },
+        "flash": {
+            "familyname": "Flash",
+            "name": "Animate",
+            "ids": ["FLPR"],
+            "version": { "min": "26.0", "max": "26.9" },
+            "bin": { "win": "Animate.exe", "mac": "Adobe Animate 2026.app" },
+            "x64": true
+        },
+        "aftereffects": {
+            "familyname": "AfterEffects",
+            "name": "After Effects",
+            "ids": ["AEFT"],
+            "version": { "min": "22.0", "max": "22.9" },
+            "bin": { "win": "Support Files/AfterFX.exe", "mac": "Adobe After Effects 2026.app" },
+            "x64": true
+        },
+        "premiere": {
+            "familyname": "Premiere",
+            "name": "Premiere Pro",
+            "ids": ["PPRO"],
+            "version": { "min": "19.0", "max": "19.9" },
+            "bin": { "win": "Adobe Premiere Pro.exe", "mac": "Adobe Premiere Pro 2026.app" },
+            "x64": true
+        },
+        "prelude": {
+            "familyname": "Prelude",
+            "name": "Prelude",
+            "ids": ["PRLD"],
+            "version": { "min": "14.0", "max": "14.9" },
+            "bin": { "win": "Prelude.exe", "mac": "Adobe Prelude 2026.app" },
+            "x64": false
+        },
+        "dreamweaver": {
+            "familyname": "Dreamweaver",
+            "name": "Dreamweaver",
+            "ids": ["DRWV"],
+            "version": { "min": "26.0", "max": "26.9" },
+            "bin": { "win": "Dreamweaver.exe", "mac": "Adobe Dreamweaver 2026.app" },
+            "x64": false
+        },
+        "incopy": {
+            "familyname": "InCopy",
+            "name": "InCopy",
+            "ids": ["AICY"],
+            "version": { "min": "21.0", "max": "21.9" },
+            "bin": { "win": "InCopy.exe", "mac": "Adobe InCopy 2026.app" },
+            "x64": true
+        }
+    },
     "CC2025": {
         "photoshop": {
             "familyname": "Photoshop",


### PR DESCRIPTION
## Summary
- Add CC2026 host definitions to `hosts.json` (Illustrator 30.x, Photoshop 27.x, InDesign 21.x, etc.)
- Add `manifest.bundle.cc2026.xml` template with `CSXS Version="12.0"` requirement
- Update default product family to CC2026 in `cep.js`
- Add CC2026 debug mode entries (plist/registry) for macOS and Windows in `compiler.js`

This follows the same pattern as the CC2025 additions and includes the upstream CEP 12 changes merged from master.

## Context
Adobe Illustrator 2026 (v30.x) ships with CEP 12. Without this update, extensions built with grunt-cep are capped at Illustrator 29.9 and won't load in the new version.